### PR TITLE
Do not try to manipulate last messages item if there is None

### DIFF
--- a/clang_tidy_converter/parser/clang_tidy_parser.py
+++ b/clang_tidy_converter/parser/clang_tidy_parser.py
@@ -50,7 +50,10 @@ class ClangTidyParser:
                 continue
             message = self._parse_message(line)
             if message is None or message.level == ClangMessage.Level.UNKNOWN:
-                messages[-1].details_lines.append(line)
+                if messages:
+                    messages[-1].details_lines.append(line)
+                else:
+                    continue
             else:
                 messages.append(message)
         return self._group_messages(messages)


### PR DESCRIPTION
Hi @yuriisk 

First of all thanks for this program. I use it in my CI and it helps me a lot. 
Recently i have been facing a crash during its use.
I got an IndexError line 54.

This PR tries to fix it. 

If `messages` has not been populated yet, then we must not manipulate its last item.

Thanks again