### PR TITLE
Add SARIF and SonarQube formatters

### DIFF
--- a/clang_tidy_converter/__main__.py
+++ b/clang_tidy_converter/__main__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from .formatter import CodeClimateFormatter, HTMLReportFormatter
+from .formatter import CodeClimateFormatter, HTMLReportFormatter, SonarQubeFormatter, SarifFormatter
 from .parser import ClangTidyParser
 from argparse import ArgumentParser
 import os
@@ -20,6 +20,10 @@ def create_argparser():
 
     html = sub.add_parser("html", help="HTML report")
     html.add_argument('-s', '--software_name', default='', help='software name to display in generated report')
+
+    sq = sub.add_parser("sq", help="SonarQube JSON")
+    sarif = sub.add_parser("sarif", help="SARIF JSON")
+
     return p
 
 def main(args):
@@ -31,6 +35,10 @@ def main(args):
 
     if args.output_format == 'cc':
         formatter = CodeClimateFormatter()
+    elif args.output_format == 'sarif':
+        formatter = SarifFormatter()
+    elif args.output_format == 'sq':
+        formatter = SonarQubeFormatter()
     else:
         formatter = HTMLReportFormatter()
 

--- a/clang_tidy_converter/formatter/__init__.py
+++ b/clang_tidy_converter/formatter/__init__.py
@@ -1,2 +1,4 @@
 from .code_climate_formatter import CodeClimateFormatter
 from .html_report_formatter import HTMLReportFormatter
+from .sonarqube_formatter import SonarQubeFormatter
+from .sarif_formatter import SarifFormatter

--- a/clang_tidy_converter/formatter/sarif_formatter.py
+++ b/clang_tidy_converter/formatter/sarif_formatter.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import json
+
+from ..parser import ClangMessage
+
+
+class SarifFormatter:
+    """
+    Follows the SARIF format as used by SonarQube
+    https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/importing-external-issues/importing-issues-from-sarif-reports/
+    """
+
+    def format(self, messages, args):
+        return json.dumps({
+            "version": "2.1.0",
+            "runs": [{
+                "tool": {"driver": {"name": "clang-tidy"}},
+                "results": [self._format_message(msg, args) for msg in messages]
+            }]
+        }, indent=2)
+
+    def _format_message(self, message: ClangMessage, args):
+        return {
+            "message": {"text": message.message},
+            "ruleId": message.diagnostic_name,
+            "locations": [self._format_location(msg, args) for msg in [
+                message, *message.children]],
+            "level": self._convert_level(message.level),
+        }
+
+    def _format_location(self, message, args):
+        return {
+            "message": message.message,
+            "artifactLocation": {"uri": "file://" + message.filepath},
+            "region": {
+                "startLine": message.line,
+                "startColumn": message.column,
+            },
+        }
+
+    def _convert_level(self, level, default=""):
+        return {
+            ClangMessage.Level.NOTE: "none",
+            ClangMessage.Level.REMARK: "note",
+            ClangMessage.Level.WARNING: "warning",
+            ClangMessage.Level.ERROR: "error",
+            ClangMessage.Level.FATAL: "error",
+        }.get(level, default)

--- a/clang_tidy_converter/formatter/sonarqube_formatter.py
+++ b/clang_tidy_converter/formatter/sonarqube_formatter.py
@@ -27,13 +27,20 @@ class SonarQubeFormatter:
         }
 
     def _format_location(self, message, args):
+        range = {
+            "startLine": message.line,
+            "endLine": message.line,
+        }
+        if message.column > 0:
+            range["startColumn"] = message.column - 1
+            range["endColumn"] = message.column
+        else:
+            range["startColumn"] = 0
+            range["endColumn"] = 1
         return {
             "message": message.message,
             "filePath": message.filepath,
-            "textRange": {
-                "startLine": message.line,
-                "startColumn": message.column,
-            },
+            "textRange": range,
         }
 
     def _level_to_severity(self, level, default="BLOCKER"):

--- a/clang_tidy_converter/formatter/sonarqube_formatter.py
+++ b/clang_tidy_converter/formatter/sonarqube_formatter.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import json
+
+from ..parser import ClangMessage
+
+
+class SonarQubeFormatter:
+    """
+    The JSON format used to import external issues into SonarQube
+    https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/importing-external-issues/generic-issue-import-format/
+    """
+
+    def format(self, messages, args):
+        return json.dumps({"issues": [self._format_message(msg, args) for msg in messages]}, indent=2)
+
+    def _format_message(self, message: ClangMessage, args):
+        return {
+            "engineId": "clang-tidy",  # String
+            "ruleId": message.diagnostic_name,  # String
+            "primaryLocation": self._format_location(message, args),  # Location object
+            "type": "CODE_SMELL",  # String. One of BUG, VULNERABILITY, CODE_SMELL
+            "severity": self._level_to_severity(message.level),  # String. One of BLOCKER, CRITICAL, MAJOR, MINOR, INFO
+            # "effortMinutes": "", # Integer, optional. Defaults to 0
+            "secondaryLocations": [self._format_location(msg, args) for msg in message.children],  # Array of Location objects, optional
+            # "_details": message.details_lines
+        }
+
+    def _format_location(self, message, args):
+        return {
+            "message": message.message,
+            "filePath": message.filepath,
+            "textRange": {
+                "startLine": message.line,
+                "startColumn": message.column,
+            },
+        }
+
+    def _level_to_severity(self, level, default="BLOCKER"):
+        return {
+            ClangMessage.Level.NOTE: "INFO",
+            ClangMessage.Level.REMARK: "MINOR",
+            ClangMessage.Level.WARNING: "MAJOR",
+            ClangMessage.Level.ERROR: "CRITICAL",
+            ClangMessage.Level.FATAL: "BLOCKER",
+        }.get(level, default)


### PR DESCRIPTION
This adds two formatters to be used with SonarQube/SonarCloud and other tools supporting the [Static Analysis Results Interchange Format (SARIF)](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) according to the specs given here:
https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/importing-external-issues/importing-issues-from-sarif-reports/
https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/importing-external-issues/generic-issue-import-format/