### PR TITLE
Adding entry point in setup.py for easier installation

### DIFF
--- a/clang_tidy_converter/__main__.py
+++ b/clang_tidy_converter/__main__.py
@@ -26,7 +26,8 @@ def create_argparser():
 
     return p
 
-def main(args):
+def main():
+    args = create_argparser().parse_args()
     parser = ClangTidyParser()
     messages = parser.parse(sys.stdin.readlines())
 
@@ -50,4 +51,4 @@ def convert_paths_to_relative(messages, root_dir):
         convert_paths_to_relative(message.children, root_dir)
 
 if __name__ == "__main__":
-    main(create_argparser().parse_args())
+    main()

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,10 @@ setup(
     setup_requires=['pytest-runner', 'wheel'],
     tests_require=['pytest'],
     classifiers=[],
+    entry_points={
+        'console_scripts': [
+            'clang_tidy_converter=clang_tidy_converter.__main__:main',
+        ],
+    },
 )
 


### PR DESCRIPTION
Now this app can be installed via 
```
pipx install  git+https://github.com/yuriisk/clang-tidy-converter.git
```
or
```
pipx install PATH_TO/clang-tidy-converter
```
and can be used just by calling app
```
clang_tidy_converter 
```
Example output

```
user@6ef019d15165:~$ clang_tidy_converter 
usage: clang_tidy_converter [-h] [-r PROJECT_ROOT] FORMAT ...
clang_tidy_converter: error: the following arguments are required: FORMAT
```